### PR TITLE
initialize argument error

### DIFF
--- a/lib/fluent/plugin/in_http_ex.rb
+++ b/lib/fluent/plugin/in_http_ex.rb
@@ -46,7 +46,7 @@ class ExHttpInput < HttpInput
     detach_multi_process do
       Input.new.start
       @km = KeepaliveManager.new(@keepalive_timeout)
-      @lsock = Coolio::TCPServer.new(lsock, nil, ExHandler, @km, method(:on_request), @body_size_limit, $log)
+      @lsock = Coolio::TCPServer.new(lsock, nil, ExHandler, @km, method(:on_request), @body_size_limit, nil, $log)
 
       @loop = Coolio::Loop.new
       @loop.attach(@km)


### PR DESCRIPTION
After fluentd 0.10.49, fluent-plugin-http-ex 0.0.2 raises ArgumentError again. The reason is Hander#initialize(in original in_http.rb) arguments was increased.
- https://github.com/fluent/fluentd/blob/v0.10.48/lib/fluent/plugin/in_http.rb#L156
- https://github.com/fluent/fluentd/blob/v0.10.49/lib/fluent/plugin/in_http.rb#L195

To fix this, fluent-plugin-http-ex should support format argument.
